### PR TITLE
not working with dbt 0.21.0

### DIFF
--- a/dbt/adapters/exasol/connections.py
+++ b/dbt/adapters/exasol/connections.py
@@ -36,7 +36,7 @@ class ExasolCredentials(Credentials):
     password: str
     database: str
     schema: str
-    protocol_version: str = '3'
+    protocol_version: str = "v3"
 
     _ALIASES = {
         'dbname': 'database',
@@ -84,7 +84,8 @@ class ExasolConnectionManager(SQLConnectionManager):
 
         # Support protocol versions
         try:
-            version = ProtocolVersionType(credentials.protocol_version)
+            format_protocol_version = credentials.protocol_version.lower()
+            version = ProtocolVersionType(format_protocol_version)
 
             if version == ProtocolVersionType.V1:
                 protocol_version = pyexasol.PROTOCOL_V1

--- a/dbt/adapters/exasol/connections.py
+++ b/dbt/adapters/exasol/connections.py
@@ -84,7 +84,7 @@ class ExasolConnectionManager(SQLConnectionManager):
 
         # Support protocol versions
         try:
-            version = ProtocolVersionType[credentials.protocol_version]
+            version = ProtocolVersionType(credentials.protocol_version)
 
             if version == ProtocolVersionType.V1:
                 protocol_version = pyexasol.PROTOCOL_V1

--- a/dbt/adapters/exasol/connections.py
+++ b/dbt/adapters/exasol/connections.py
@@ -45,6 +45,10 @@ class ExasolCredentials(Credentials):
     def type(self):
         return 'exasol'
 
+    @property
+    def unique_field(self):
+        return self.dsn
+
     def _connection_keys(self):
         return ('dsn', 'user', 'database', 'schema')
 

--- a/dbt/adapters/exasol/connections.py
+++ b/dbt/adapters/exasol/connections.py
@@ -4,6 +4,7 @@ import time
 import dbt.exceptions
 from dbt.adapters.base import Credentials
 from dbt.adapters.sql import SQLConnectionManager
+from dbt.adapters.exasol.relation import ProtocolVersionType
 from dbt.logger import GLOBAL_LOGGER as logger
 from dbt.contracts.connection import AdapterResponse
 from typing import Optional
@@ -35,6 +36,7 @@ class ExasolCredentials(Credentials):
     password: str
     database: str
     schema: str
+    protocol_version: str = '3'
 
     _ALIASES = {
         'dbname': 'database',
@@ -50,7 +52,7 @@ class ExasolCredentials(Credentials):
         return self.dsn
 
     def _connection_keys(self):
-        return ('dsn', 'user', 'database', 'schema')
+        return ('dsn', 'user', 'database', 'schema', 'protocol_version')
 
 
 class ExasolConnectionManager(SQLConnectionManager):
@@ -79,9 +81,25 @@ class ExasolConnectionManager(SQLConnectionManager):
             logger.debug('Connection is already open, skipping open.')
             return connection
         credentials = cls.get_credentials(connection.credentials)
+
+        # Support protocol versions
+        try:
+            version = ProtocolVersionType[credentials.protocol_version]
+
+            if version == ProtocolVersionType.V1:
+                protocol_version = pyexasol.PROTOCOL_V1
+            elif version == ProtocolVersionType.V2:
+                protocol_version = pyexasol.PROTOCOL_V2
+            else:
+                protocol_version = pyexasol.PROTOCOL_V3    
+        except:
+            raise dbt.exceptions.RuntimeException(f"{credentials.protocol_version} is not a valid protocol version.")
+
+
+
         try:
             C = connect(dsn=credentials.dsn, user=credentials.user,
-                        password=credentials.password, autocommit=True)
+                        password=credentials.password, autocommit=True, protocol_version=protocol_version)
             connection.handle = C
             connection.state = 'open'
 

--- a/dbt/adapters/exasol/relation.py
+++ b/dbt/adapters/exasol/relation.py
@@ -13,9 +13,9 @@ class RelationType(StrEnum):
 
 
 class ProtocolVersionType(StrEnum):
-    V1 = '1'
-    V2 = '2'
-    V3 = '3'
+    V1 = 'v1'
+    V2 = 'v2'
+    V3 = 'v3'
 
 
 @dataclass

--- a/dbt/adapters/exasol/relation.py
+++ b/dbt/adapters/exasol/relation.py
@@ -11,6 +11,13 @@ class RelationType(StrEnum):
     MaterializedView = 'materializedview'
     External = 'external'
 
+
+class ProtocolVersionType(StrEnum):
+    V1 = '1'
+    V2 = '2'
+    V3 = '3'
+
+
 @dataclass
 class ExasolQuotePolicy(Policy):
     database: bool = False


### PR DESCRIPTION
I'm quite new to dbt, but i could not make version 0.21.0 work with the dbt-exasol.

I kept getting error `Can't instantiate abstract class ExasolCredentials with abstract methods unique_field`

After a little research it looks like u have to implement the function `unique_field` for the adapter to work: https://docs.getdbt.com/docs/contributing/building-a-new-adapter

Beside that i was not able to get the adapter to work with older Exasol versions like 6.0.0 due to Pyexasol protocol_version. 

It might need to be a little cleaner, but i've added `protocol_version` as a config and added `unique_field` function 
