### PR TITLE
Add persist_docs support

### DIFF
--- a/dbt/include/exasol/macros/adapters.sql
+++ b/dbt/include/exasol/macros/adapters.sql
@@ -127,7 +127,7 @@ ALTER_COLUMN_TYPE_MACRO_NAME = 'alter_column_type'
 
 {% macro exasol__alter_relation_comment(relation, relation_comment) -%}
   {%- set comment = relation_comment | replace("'", '"') %}
-  comment on {{ relation.type }} {{ relation }} IS '{{ comment }}';
+  COMMENT ON {{ relation.type }} {{ relation }} IS '{{ comment }}';
 {% endmacro %}
 
 {% macro get_column_comment_sql(column_name, column_dict) -%}
@@ -150,7 +150,7 @@ ALTER_COLUMN_TYPE_MACRO_NAME = 'alter_column_type'
 
 {% macro exasol__alter_column_comment(relation, column_dict) -%}
     {% set existing_columns = adapter.get_columns_in_relation(relation) | map(attribute="name") | list %}
-    comment on {{ relation.type }} {{ relation }} (
+    COMMENT ON {{ relation.type }} {{ relation }} (
     {% for column_name in existing_columns if (column_name in existing_columns) or (column_name|lower in existing_columns) %}
         {{ get_column_comment_sql(column_name, column_dict) }} {{- ',' if not loop.last }}
     {% endfor %}

--- a/dbt/include/exasol/macros/materializations/incremental.sql
+++ b/dbt/include/exasol/macros/materializations/incremental.sql
@@ -68,5 +68,7 @@
 
   {{ run_hooks(post_hooks, inside_transaction=False) }}
 
+  {% do persist_docs(target_relation, model) %}
+
   {{ return({'relations': [target_relation]}) }}
 {%- endmaterialization %}

--- a/dbt/include/exasol/macros/materializations/table.sql
+++ b/dbt/include/exasol/macros/materializations/table.sql
@@ -68,5 +68,8 @@
   {{ drop_relation_if_exists(intermediate_relation) }}
 
   {{ run_hooks(post_hooks, inside_transaction=False) }}
+
+  {{ persist_docs(target_relation, model) }}
+
   {{ return({'relations': [target_relation]}) }}
 {% endmaterialization %}


### PR DESCRIPTION
Closes #21 and adds support for the dbt [persist_docs](https://docs.getdbt.com/reference/resource-configs/persist_docs) feature.

For tables the `COMMENT ON` statement is executed on materialization (table/incremental). For views the column comments and view comment is directly added to the SQL code. This is because Exasol didn't support to run the `COMMENT` statement on views.