### PR TITLE
Add cross-database macros

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,23 @@
+# See here for image contents: https://github.com/microsoft/vscode-dev-containers/tree/v0.245.0/containers/python-3/.devcontainer/base.Dockerfile
+
+# [Choice] Python version (use -bullseye variants on local arm64/Apple Silicon): 3, 3.10, 3.9, 3.8, 3.7, 3.6, 3-bullseye, 3.10-bullseye, 3.9-bullseye, 3.8-bullseye, 3.7-bullseye, 3.6-bullseye, 3-buster, 3.10-buster, 3.9-buster, 3.8-buster, 3.7-buster, 3.6-buster
+ARG VARIANT="3.10-bullseye"
+FROM mcr.microsoft.com/vscode/devcontainers/python:0-${VARIANT}
+
+# [Choice] Node.js version: none, lts/*, 16, 14, 12, 10
+ARG NODE_VERSION="none"
+RUN if [ "${NODE_VERSION}" != "none" ]; then su vscode -c "umask 0002 && . /usr/local/share/nvm/nvm.sh && nvm install ${NODE_VERSION} 2>&1"; fi
+
+# [Optional] If your pip requirements rarely change, uncomment this section to add them to the image.
+# COPY requirements.txt /tmp/pip-tmp/
+# RUN pip3 --disable-pip-version-check --no-cache-dir install -r /tmp/pip-tmp/requirements.txt \
+#    && rm -rf /tmp/pip-tmp
+
+# [Optional] Uncomment this section to install additional OS packages.
+# RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
+#     && apt-get -y install --no-install-recommends <your-package-list-here>
+
+# [Optional] Uncomment this line to install global node packages.
+# RUN su vscode -c "source /usr/local/share/nvm/nvm.sh && npm install -g <your-package-here>" 2>&1
+
+CMD [ "sleep", "infinity" ]

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,46 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the README at:
+// https://github.com/microsoft/vscode-dev-containers/tree/v0.245.0/containers/python-3
+{
+	"name": "Python 3",
+	"dockerComposeFile": [
+		"../docker-compose.yml"
+	],
+	"service": "devcontainer",
+	"workspaceFolder": "/workspace",
+	// Configure tool-specific properties.
+	"customizations": {
+		// Configure properties specific to VS Code.
+		"vscode": {
+			// Set *default* container specific settings.json values on container create.
+			"settings": { 
+				"python.defaultInterpreterPath": "/usr/local/bin/python",
+				"python.linting.enabled": true,
+				"python.linting.pylintEnabled": true,
+				"python.formatting.autopep8Path": "/usr/local/py-utils/bin/autopep8",
+				"python.formatting.blackPath": "/usr/local/py-utils/bin/black",
+				"python.formatting.yapfPath": "/usr/local/py-utils/bin/yapf",
+				"python.linting.banditPath": "/usr/local/py-utils/bin/bandit",
+				"python.linting.flake8Path": "/usr/local/py-utils/bin/flake8",
+				"python.linting.mypyPath": "/usr/local/py-utils/bin/mypy",
+				"python.linting.pycodestylePath": "/usr/local/py-utils/bin/pycodestyle",
+				"python.linting.pydocstylePath": "/usr/local/py-utils/bin/pydocstyle",
+				"python.linting.pylintPath": "/usr/local/py-utils/bin/pylint"
+			},
+			
+			// Add the IDs of extensions you want installed when the container is created.
+			"extensions": [
+				"ms-python.python",
+				"ms-python.vscode-pylance"
+			]
+		}
+	},
+
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	// "forwardPorts": [],
+
+	// Use 'postCreateCommand' to run commands after the container is created.
+	"postCreateCommand": "pip3 install --user -e .",
+
+	// Comment out to connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
+	"remoteUser": "vscode"
+}

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,5 @@
+# https://git-scm.com/docs/gitattributes
+*       text=auto working-tree-encoding=UTF-8 eol=lf
+*.bat   text eol=crlf
+*.cmd   text eol=crlf
+*.ps*   text eol=crlf

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,4 @@
 {
-    "python.pythonPath": "/home/torsten/.cache/pypoetry/virtualenvs/samplestack-Oe29XQGw-py3.8/bin/python",
     "python.linting.pylintEnabled": true,
     "python.linting.enabled": true
 }

--- a/dbt/adapters/exasol/__init__.py
+++ b/dbt/adapters/exasol/__init__.py
@@ -1,5 +1,6 @@
 from dbt.adapters.exasol.connections import ExasolConnectionManager
 from dbt.adapters.exasol.connections import ExasolCredentials
+from dbt.adapters.exasol.column import ExasolColumn
 from dbt.adapters.exasol.relation import ExasolRelation
 from dbt.adapters.exasol.impl import ExasolAdapter
 
@@ -10,4 +11,5 @@ from dbt.include import exasol
 Plugin = AdapterPlugin(
     adapter=ExasolAdapter,
     credentials=ExasolCredentials,
-    include_path=exasol.PACKAGE_PATH)
+    include_path=exasol.PACKAGE_PATH,
+)

--- a/dbt/adapters/exasol/column.py
+++ b/dbt/adapters/exasol/column.py
@@ -1,12 +1,22 @@
 import re
 from dataclasses import dataclass
-
+from typing import ClassVar, Dict
 from dbt.adapters.base.column import Column
 from dbt.exceptions import RuntimeException
 
 
 @dataclass
 class ExasolColumn(Column):
+    # https://docs.exasol.com/db/latest/sql_references/data_types/datatypealiases.htm
+    TYPE_LABELS: ClassVar[Dict[str, str]] = {
+        "STRING": "VARCHAR(200000) UTF8",
+        "TIMESTAMP": "TIMESTAMP",
+        "FLOAT": "DOUBLE PRECISION",
+        "INTEGER": "DECIMAL(18,0)",
+        "BIGINT": "DECIMAL(36,0)",
+        "NUMERIC": "DECIMAL(18,9)",
+    }
+
     def is_integer(self) -> bool:
         # everything that smells like an int is actually a DECIMAL(18, 0)
         return True if self.is_numeric() and self.numeric_scale == 0 else False

--- a/dbt/adapters/exasol/column.py
+++ b/dbt/adapters/exasol/column.py
@@ -9,7 +9,7 @@ from dbt.exceptions import RuntimeException
 class ExasolColumn(Column):
     # https://docs.exasol.com/db/latest/sql_references/data_types/datatypealiases.htm
     TYPE_LABELS: ClassVar[Dict[str, str]] = {
-        "STRING": "VARCHAR(200000) UTF8",
+        "STRING": "VARCHAR(2000000) UTF8",
         "TIMESTAMP": "TIMESTAMP",
         "FLOAT": "DOUBLE PRECISION",
         "INTEGER": "DECIMAL(18,0)",

--- a/dbt/adapters/exasol/column.py
+++ b/dbt/adapters/exasol/column.py
@@ -1,0 +1,85 @@
+import re
+from dataclasses import dataclass
+
+from dbt.adapters.base.column import Column
+from dbt.exceptions import RuntimeException
+
+
+@dataclass
+class ExasolColumn(Column):
+    def is_integer(self) -> bool:
+        # everything that smells like an int is actually a DECIMAL(18, 0)
+        return True if self.is_numeric() and self.numeric_scale == 0 else False
+
+    def is_float(self):
+        return self.dtype.lower() == "double"
+
+    def is_string(self) -> bool:
+        return self.dtype.lower() in ["char", "varchar"]
+
+    def is_hashtype(self) -> bool:
+        return self.dtype.lower() == "hashtype"
+
+    def is_boolean(self) -> bool:
+        return self.dtype.lower() == "boolean"
+
+    def is_timestamp(self) -> bool:
+        # handle TIMESTAMP and TIMESTAMP WITH LOCAL TIME ZONE
+        return self.dtype.lower().startswith("timestamp")
+
+    def is_date(self) -> bool:
+        return self.dtype.lower() == "date"
+
+    def string_size(self) -> int:
+        if not self.is_string():
+            raise RuntimeException("Called string_size() on non-string field!")
+        print(self.dtype)
+        if self.char_size is None:
+            return 2000000
+        else:
+            return int(self.char_size)
+
+    @classmethod
+    def string_type(cls, size: int) -> str:
+        return f"VARCHAR({size})"
+
+    @classmethod
+    def from_description(cls, name: str, raw_data_type: str) -> "Column":
+        match = re.match(r"([^(]+)(\([^)]+\))?", raw_data_type)
+        if match is None:
+            raise RuntimeException(f'Could not interpret data type "{raw_data_type}"')
+        data_type, size_info = match.groups()
+        char_size = None
+        numeric_precision = None
+        numeric_scale = None
+        if size_info is not None:
+            # strip out the parentheses
+            size_info = size_info[1:-1]
+            parts = size_info.split(",")
+            if len(parts) == 1:
+                try:
+                    # handle things like HASHTYPE(16 BYTE)
+                    size = re.sub(r"[^\d]", "", parts[0])
+                    char_size = int(size)
+                except ValueError:
+                    raise RuntimeException(
+                        f'Could not interpret data_type "{raw_data_type}": '
+                        f'could not convert "{size}" to an integer'
+                    )
+            elif len(parts) == 2:
+                try:
+                    numeric_precision = int(parts[0])
+                except ValueError:
+                    raise RuntimeException(
+                        f'Could not interpret data_type "{raw_data_type}": '
+                        f'could not convert "{parts[0]}" to an integer'
+                    )
+                try:
+                    numeric_scale = int(parts[1])
+                except ValueError:
+                    raise RuntimeException(
+                        f'Could not interpret data_type "{raw_data_type}": '
+                        f'could not convert "{parts[1]}" to an integer'
+                    )
+
+        return cls(name, data_type, char_size, numeric_precision, numeric_scale)

--- a/dbt/adapters/exasol/impl.py
+++ b/dbt/adapters/exasol/impl.py
@@ -3,6 +3,7 @@ from __future__ import absolute_import
 from dbt.adapters.sql import SQLAdapter
 from dbt.adapters.exasol import ExasolConnectionManager
 from dbt.adapters.exasol import ExasolRelation
+from dbt.adapters.exasol import ExasolColumn
 from dbt.logger import GLOBAL_LOGGER as logger
 from dbt.utils import filter_null_values
 import dbt.flags
@@ -12,11 +13,12 @@ import agate
 
 class ExasolAdapter(SQLAdapter):
     Relation = ExasolRelation
+    Column = ExasolColumn
     ConnectionManager = ExasolConnectionManager
 
     @classmethod
     def date_function(cls):
-        return 'current_timestamp()'
+        return "current_timestamp()"
 
     @classmethod
     def is_cancelable(cls):
@@ -30,23 +32,23 @@ class ExasolAdapter(SQLAdapter):
         self, database: str, schema: str, identifier: str
     ) -> Dict[str, str]:
         quoting = self.config.quoting
-        if identifier is not None and quoting['identifier'] is False:
+        if identifier is not None and quoting["identifier"] is False:
             identifier = identifier.lower()
 
-        if schema is not None and quoting['schema'] is False:
+        if schema is not None and quoting["schema"] is False:
             schema = schema.lower()
 
-        if database is not None and quoting['database'] is False:
+        if database is not None and quoting["database"] is False:
             database = database.lower()
 
-        return filter_null_values({
-            'identifier': identifier,
-            'schema': schema,
-        })
+        return filter_null_values(
+            {
+                "identifier": identifier,
+                "schema": schema,
+            }
+        )
 
     @classmethod
-    def convert_number_type(
-        cls, agate_table: agate.Table, col_idx: int
-    ) -> str:
+    def convert_number_type(cls, agate_table: agate.Table, col_idx: int) -> str:
         decimals = agate_table.aggregate(agate.MaxPrecision(col_idx))
         return "float" if decimals else "integer"

--- a/dbt/include/exasol/macros/adapters.sql
+++ b/dbt/include/exasol/macros/adapters.sql
@@ -127,7 +127,7 @@ ALTER_COLUMN_TYPE_MACRO_NAME = 'alter_column_type'
 
 {% macro exasol__alter_relation_comment(relation, relation_comment) -%}
   {%- set comment = relation_comment | replace("'", '"') %}
-  comment on {{ relation.type }} {{ relation }} IS '{{ comment }}';
+  COMMENT ON {{ relation.type }} {{ relation }} IS '{{ comment }}';
 {% endmacro %}
 
 {% macro get_column_comment_sql(column_name, column_dict) -%}
@@ -150,7 +150,7 @@ ALTER_COLUMN_TYPE_MACRO_NAME = 'alter_column_type'
 
 {% macro exasol__alter_column_comment(relation, column_dict) -%}
     {% set existing_columns = adapter.get_columns_in_relation(relation) | map(attribute="name") | list %}
-    comment on {{ relation.type }} {{ relation }} (
+    COMMENT ON {{ relation.type }} {{ relation }} (
     {% for column_name in existing_columns if (column_name in existing_columns) or (column_name|lower in existing_columns) %}
         {{ get_column_comment_sql(column_name, column_dict) }} {{- ',' if not loop.last }}
     {% endfor %}

--- a/dbt/include/exasol/macros/materializations/incremental.sql
+++ b/dbt/include/exasol/macros/materializations/incremental.sql
@@ -68,5 +68,7 @@
 
   {{ run_hooks(post_hooks, inside_transaction=False) }}
 
+  {% do persist_docs(target_relation, model) %}
+
   {{ return({'relations': [target_relation]}) }}
 {%- endmaterialization %}

--- a/dbt/include/exasol/macros/materializations/table.sql
+++ b/dbt/include/exasol/macros/materializations/table.sql
@@ -68,5 +68,8 @@
   {{ drop_relation_if_exists(intermediate_relation) }}
 
   {{ run_hooks(post_hooks, inside_transaction=False) }}
+
+  {{ persist_docs(target_relation, model) }}
+
   {{ return({'relations': [target_relation]}) }}
 {% endmaterialization %}

--- a/dbt/include/exasol/macros/utils/any_value.sql
+++ b/dbt/include/exasol/macros/utils/any_value.sql
@@ -1,0 +1,7 @@
+{#- /*Exasol doesn't support any_value, so we're using min() to get the same result*/ -#}
+
+{% macro exasol__any_value(expression) -%}
+
+    min({{ expression }})
+
+{%- endmacro %}

--- a/dbt/include/exasol/macros/utils/bool_or.sql
+++ b/dbt/include/exasol/macros/utils/bool_or.sql
@@ -1,0 +1,5 @@
+{% macro exasol__bool_or(expression) -%}
+
+    any({{ expression }})
+
+{%- endmacro %}

--- a/dbt/include/exasol/macros/utils/dateadd.sql
+++ b/dbt/include/exasol/macros/utils/dateadd.sql
@@ -1,0 +1,9 @@
+{% macro exasol__dateadd(datepart, interval, from_date_or_timestamp) %}
+    {%- set supported_dateparts = ["year", "month", "week", "day", "hour", "minute", "second"] %}
+    {%- if datepart | lower not in supported_dateparts %}
+    {{ exceptions.raise_compiler_error("Unsupported `datepart`! Use one of " ~ ','.join(supported_dateparts) ~ "!") }}
+    {%- endif -%}
+    
+    add_{{ datepart | lower }}s({{ from_date_or_timestamp }}, {{ interval }})
+
+{%- endmacro %}

--- a/dbt/include/exasol/macros/utils/datediff.sql
+++ b/dbt/include/exasol/macros/utils/datediff.sql
@@ -1,0 +1,9 @@
+{% macro exasol__datediff(first_date, second_date, datepart) %}
+    {%- set supported_dateparts = ["year", "month", "day", "hour", "minute", "second"] %}
+    {%- if datepart | lower not in supported_dateparts %}
+    {{ exceptions.raise_compiler_error("Unsupported `datepart`! Use one of " ~ ','.join(supported_dateparts) ~ "!") }}
+    {%- endif -%}
+    
+    {{ datepart | lower }}s_between({{ first_date }}, {{ second_date }})
+
+{%- endmacro %}

--- a/dbt/include/exasol/macros/utils/hash.sql
+++ b/dbt/include/exasol/macros/utils/hash.sql
@@ -1,0 +1,3 @@
+{% macro exasol__hash(field) -%}
+    hashtype_md5(cast({{ field }} as {{ api.Column.translate_type('string') }}))
+{%- endmacro %}

--- a/dbt/include/exasol/macros/utils/listagg.sql
+++ b/dbt/include/exasol/macros/utils/listagg.sql
@@ -1,0 +1,14 @@
+{% macro exasol__listagg(measure, delimiter_text, order_by_clause, limit_num) -%}
+    {% if limit_num -%}
+    {{ exceptions.raise_compiler_error("`limit_num` parameter is not supported on Exasol!") }}
+    {% endif -%}
+
+    listagg(
+        {{ measure }},
+        {{ delimiter_text }}
+        )
+        {% if order_by_clause -%}
+        within group ({{ order_by_clause }})
+        {%- endif %}
+
+{%- endmacro %}

--- a/dbt/include/exasol/macros/utils/safe_cast.sql
+++ b/dbt/include/exasol/macros/utils/safe_cast.sql
@@ -1,0 +1,14 @@
+{% macro exasol__safe_cast(field, type) %}
+    {%- if type | lower == "boolean" -%}
+    CASE WHEN is_boolean({{ field }}) THEN cast({{ field }} as {{ type }}) ELSE null END
+    {%- elif type | lower == "timestamp" -%}
+    CASE WHEN is_timestamp({{ field }}) THEN cast({{ field }} as {{ type }}) ELSE null END
+    {%- elif type | lower == "date" -%}
+    CASE WHEN is_date({{ field }}) THEN cast({{ field }} as {{ type }}) ELSE null END
+    {%- elif type.lower().startswith("decimal") or type.lower().startswith("double") or type in ["int", "float"] -%}
+    CASE WHEN is_number({{ field }}) THEN cast({{ field }} as {{ type }}) ELSE null END
+    {%- else -%}
+    {#- try to cast it anyway...e.g. strings -#}
+    cast({{ field }} as {{ type }})
+    {%- endif -%}
+{% endmacro %}

--- a/dbt/include/exasol/macros/utils/split_part.sql
+++ b/dbt/include/exasol/macros/utils/split_part.sql
@@ -1,0 +1,5 @@
+{% macro exasol__split_part(string_text, delimiter_text, part_number) %}
+
+  {{ exceptions.raise_compiler_error("Unsupported on Exasol! Sorry...") }}
+
+{% endmacro %}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,46 @@
+version: "3.9"
+
+volumes:
+  dev_command_his:
+  dev_exasol:
+
+networks:
+  base:
+    driver: bridge
+    ipam:
+      driver: default
+      config:
+        - subnet: ${NETWORK__BASE_SUBNET:-172.10.2.0/24}
+
+services:
+  #######################################################
+  #   D E V C O N T A I N E R
+  #######################################################
+  devcontainer:
+    build:
+      context: .devcontainer
+      dockerfile: Dockerfile
+    init: true
+    privileged: true
+
+    volumes:
+      - .:/workspace
+      - dev_command_his:/commandhistory
+    networks:
+      base:
+
+  #######################################################
+  #   E X A S O L
+  #######################################################
+  exasol:
+    image: exasol/docker-db:${EXASOL__TAG}
+    restart: unless-stopped
+    volumes:
+      - dev_exasol:/exa
+    ports:
+      - "127.0.0.1:${EXASOL__LOCAL_PORT:-8563}:8563"
+    privileged: true
+    networks:
+      base:
+        # static ip for Exasol container
+        ipv4_address: ${EXASOL__LOCAL_IP:-172.10.2.5}


### PR DESCRIPTION
This adds the [cross-database macros](https://docs.getdbt.com/reference/dbt-jinja-functions/cross-database-macros) which were introduced in dbt v1,2,0. Most of of the default implementation is working for Exasol. This adds only Exasol specific syntax.