### PR TITLE
Add Column implementation + cross-database macros support

### DIFF
--- a/dbt/adapters/exasol/__init__.py
+++ b/dbt/adapters/exasol/__init__.py
@@ -1,5 +1,6 @@
 from dbt.adapters.exasol.connections import ExasolConnectionManager
 from dbt.adapters.exasol.connections import ExasolCredentials
+from dbt.adapters.exasol.column import ExasolColumn
 from dbt.adapters.exasol.relation import ExasolRelation
 from dbt.adapters.exasol.impl import ExasolAdapter
 
@@ -10,4 +11,5 @@ from dbt.include import exasol
 Plugin = AdapterPlugin(
     adapter=ExasolAdapter,
     credentials=ExasolCredentials,
-    include_path=exasol.PACKAGE_PATH)
+    include_path=exasol.PACKAGE_PATH,
+)

--- a/dbt/adapters/exasol/column.py
+++ b/dbt/adapters/exasol/column.py
@@ -1,0 +1,99 @@
+import re
+from dataclasses import dataclass
+from typing import ClassVar, Dict
+
+from dbt.adapters.base.column import Column
+from dbt.exceptions import RuntimeException
+
+
+@dataclass
+class ExasolColumn(Column):
+    # https://docs.exasol.com/db/latest/sql_references/data_types/datatypealiases.htm
+    TYPE_LABELS: ClassVar[Dict[str, str]] = {
+        "STRING": "VARCHAR(2000000) UTF8",
+        "TIMESTAMP": "TIMESTAMP",
+        "FLOAT": "DOUBLE PRECISION",
+        "INTEGER": "DECIMAL(18,0)",
+        "BIGINT": "DECIMAL(36,0)",
+        "NUMERIC": "DECIMAL(18,9)",
+    }
+
+    def is_numeric(self) -> bool:
+        return self.dtype.lower() in ["decimal", "double"]
+
+    def is_integer(self) -> bool:
+        # everything that smells like an int is actually a DECIMAL(18, 0)
+        return True if self.is_numeric() and self.numeric_scale == 0 else False
+
+    def is_float(self):
+        return self.dtype.lower() == "double"
+
+    def is_string(self) -> bool:
+        return self.dtype.lower() in ["char", "varchar"]
+
+    def is_hashtype(self) -> bool:
+        return self.dtype.lower() == "hashtype"
+
+    def is_boolean(self) -> bool:
+        return self.dtype.lower() == "boolean"
+
+    def is_timestamp(self) -> bool:
+        # handle TIMESTAMP and TIMESTAMP WITH LOCAL TIME ZONE
+        return self.dtype.lower().startswith("timestamp")
+
+    def is_date(self) -> bool:
+        return self.dtype.lower() == "date"
+
+    def string_size(self) -> int:
+        if not self.is_string():
+            raise RuntimeException("Called string_size() on non-string field!")
+        print(self.dtype)
+        if self.char_size is None:
+            return 2000000
+        else:
+            return int(self.char_size)
+
+    @classmethod
+    def string_type(cls, size: int) -> str:
+        return f"VARCHAR({size})"
+
+    @classmethod
+    def from_description(cls, name: str, raw_data_type: str) -> "Column":
+        match = re.match(r"([^(]+)(\([^)]+\))?", raw_data_type)
+        if match is None:
+            raise RuntimeException(f'Could not interpret data type "{raw_data_type}"')
+        data_type, size_info = match.groups()
+        char_size = None
+        numeric_precision = None
+        numeric_scale = None
+        if size_info is not None:
+            # strip out the parentheses
+            size_info = size_info[1:-1]
+            parts = size_info.split(",")
+            if len(parts) == 1:
+                try:
+                    # handle things like HASHTYPE(16 BYTE)
+                    size = re.sub(r"[^\d]", "", parts[0])
+                    char_size = int(size)
+                except ValueError:
+                    raise RuntimeException(
+                        f'Could not interpret data_type "{raw_data_type}": '
+                        f'could not convert "{size}" to an integer'
+                    )
+            elif len(parts) == 2:
+                try:
+                    numeric_precision = int(parts[0])
+                except ValueError:
+                    raise RuntimeException(
+                        f'Could not interpret data_type "{raw_data_type}": '
+                        f'could not convert "{parts[0]}" to an integer'
+                    )
+                try:
+                    numeric_scale = int(parts[1])
+                except ValueError:
+                    raise RuntimeException(
+                        f'Could not interpret data_type "{raw_data_type}": '
+                        f'could not convert "{parts[1]}" to an integer'
+                    )
+
+        return cls(name, data_type, char_size, numeric_precision, numeric_scale)

--- a/dbt/adapters/exasol/impl.py
+++ b/dbt/adapters/exasol/impl.py
@@ -1,22 +1,21 @@
 from __future__ import absolute_import
 
-from dbt.adapters.sql import SQLAdapter
-from dbt.adapters.exasol import ExasolConnectionManager
-from dbt.adapters.exasol import ExasolRelation
-from dbt.logger import GLOBAL_LOGGER as logger
-from dbt.utils import filter_null_values
-import dbt.flags
 from typing import Dict
+
 import agate
+from dbt.adapters.exasol import ExasolColumn, ExasolConnectionManager, ExasolRelation
+from dbt.adapters.sql import SQLAdapter
+from dbt.utils import filter_null_values
 
 
 class ExasolAdapter(SQLAdapter):
     Relation = ExasolRelation
+    Column = ExasolColumn
     ConnectionManager = ExasolConnectionManager
 
     @classmethod
     def date_function(cls):
-        return 'current_timestamp()'
+        return "current_timestamp()"
 
     @classmethod
     def is_cancelable(cls):
@@ -30,23 +29,23 @@ class ExasolAdapter(SQLAdapter):
         self, database: str, schema: str, identifier: str
     ) -> Dict[str, str]:
         quoting = self.config.quoting
-        if identifier is not None and quoting['identifier'] is False:
+        if identifier is not None and quoting["identifier"] is False:
             identifier = identifier.lower()
 
-        if schema is not None and quoting['schema'] is False:
+        if schema is not None and quoting["schema"] is False:
             schema = schema.lower()
 
-        if database is not None and quoting['database'] is False:
+        if database is not None and quoting["database"] is False:
             database = database.lower()
 
-        return filter_null_values({
-            'identifier': identifier,
-            'schema': schema,
-        })
+        return filter_null_values(
+            {
+                "identifier": identifier,
+                "schema": schema,
+            }
+        )
 
     @classmethod
-    def convert_number_type(
-        cls, agate_table: agate.Table, col_idx: int
-    ) -> str:
+    def convert_number_type(cls, agate_table: agate.Table, col_idx: int) -> str:
         decimals = agate_table.aggregate(agate.MaxPrecision(col_idx))
         return "float" if decimals else "integer"

--- a/dbt/include/exasol/macros/adapters.sql
+++ b/dbt/include/exasol/macros/adapters.sql
@@ -99,7 +99,7 @@ ALTER_COLUMN_TYPE_MACRO_NAME = 'alter_column_type'
   {% call statement('get_columns_in_relation', fetch_result=True) %}
       select
           column_name,
-          column_type,
+          regexp_substr(column_type, '[A-Za-z]+', 1) as column_type,
           column_maxsize,
           column_num_prec,
           column_num_scale

--- a/dbt/include/exasol/macros/utils/any_value.sql
+++ b/dbt/include/exasol/macros/utils/any_value.sql
@@ -1,0 +1,7 @@
+{#- /*Exasol doesn't support any_value, so we're using min() to get the same result*/ -#}
+
+{% macro exasol__any_value(expression) -%}
+
+    min({{ expression }})
+
+{%- endmacro %}

--- a/dbt/include/exasol/macros/utils/bool_or.sql
+++ b/dbt/include/exasol/macros/utils/bool_or.sql
@@ -1,0 +1,5 @@
+{% macro exasol__bool_or(expression) -%}
+
+    any({{ expression }})
+
+{%- endmacro %}

--- a/dbt/include/exasol/macros/utils/dateadd.sql
+++ b/dbt/include/exasol/macros/utils/dateadd.sql
@@ -1,0 +1,9 @@
+{% macro exasol__dateadd(datepart, interval, from_date_or_timestamp) %}
+    {%- set supported_dateparts = ["year", "month", "week", "day", "hour", "minute", "second"] %}
+    {%- if datepart | lower not in supported_dateparts %}
+    {{ exceptions.raise_compiler_error("Unsupported `datepart`! Use one of " ~ ','.join(supported_dateparts) ~ "!") }}
+    {%- endif -%}
+    
+    add_{{ datepart | lower }}s({{ from_date_or_timestamp }}, {{ interval }})
+
+{%- endmacro %}

--- a/dbt/include/exasol/macros/utils/datediff.sql
+++ b/dbt/include/exasol/macros/utils/datediff.sql
@@ -1,0 +1,9 @@
+{% macro exasol__datediff(first_date, second_date, datepart) %}
+    {%- set supported_dateparts = ["year", "month", "day", "hour", "minute", "second"] %}
+    {%- if datepart | lower not in supported_dateparts %}
+    {{ exceptions.raise_compiler_error("Unsupported `datepart`! Use one of " ~ ','.join(supported_dateparts) ~ "!") }}
+    {%- endif -%}
+    
+    {{ datepart | lower }}s_between({{ first_date }}, {{ second_date }})
+
+{%- endmacro %}

--- a/dbt/include/exasol/macros/utils/hash.sql
+++ b/dbt/include/exasol/macros/utils/hash.sql
@@ -1,0 +1,3 @@
+{% macro exasol__hash(field) -%}
+    hashtype_md5(cast({{ field }} as {{ api.Column.translate_type('string') }}))
+{%- endmacro %}

--- a/dbt/include/exasol/macros/utils/listagg.sql
+++ b/dbt/include/exasol/macros/utils/listagg.sql
@@ -1,0 +1,14 @@
+{% macro exasol__listagg(measure, delimiter_text, order_by_clause, limit_num) -%}
+    {% if limit_num -%}
+    {{ exceptions.raise_compiler_error("`limit_num` parameter is not supported on Exasol!") }}
+    {% endif -%}
+
+    listagg(
+        {{ measure }},
+        {{ delimiter_text }}
+        )
+        {% if order_by_clause -%}
+        within group ({{ order_by_clause }})
+        {%- endif %}
+
+{%- endmacro %}

--- a/dbt/include/exasol/macros/utils/safe_cast.sql
+++ b/dbt/include/exasol/macros/utils/safe_cast.sql
@@ -1,0 +1,14 @@
+{% macro exasol__safe_cast(field, type) %}
+    {%- if type | lower == "boolean" -%}
+    CASE WHEN is_boolean({{ field }}) THEN cast({{ field }} as {{ type }}) ELSE null END
+    {%- elif type | lower == "timestamp" -%}
+    CASE WHEN is_timestamp({{ field }}) THEN cast({{ field }} as {{ type }}) ELSE null END
+    {%- elif type | lower == "date" -%}
+    CASE WHEN is_date({{ field }}) THEN cast({{ field }} as {{ type }}) ELSE null END
+    {%- elif type.lower().startswith("decimal") or type.lower().startswith("double") or type in ["int", "float"] -%}
+    CASE WHEN is_number({{ field }}) THEN cast({{ field }} as {{ type }}) ELSE null END
+    {%- else -%}
+    {#- try to cast it anyway...e.g. strings -#}
+    cast({{ field }} as {{ type }})
+    {%- endif -%}
+{% endmacro %}

--- a/dbt/include/exasol/macros/utils/split_part.sql
+++ b/dbt/include/exasol/macros/utils/split_part.sql
@@ -1,0 +1,5 @@
+{% macro exasol__split_part(string_text, delimiter_text, part_number) %}
+
+  {{ exceptions.raise_compiler_error("Unsupported on Exasol! Sorry...") }}
+
+{% endmacro %}


### PR DESCRIPTION
This adds the implementation of the [Column](https://docs.getdbt.com/reference/dbt-classes#column) definition for the Exasol adapter. This is mainly needed for the new [cross-database macros](https://docs.getdbt.com/reference/dbt-jinja-functions/cross-database-macros) which were introduced in dbt v1,2,0 (#24). 

Most of of the default macro implementation is working for Exasol. This adds only Exasol specific syntax.

Additionally I cleaned up the imports of the `impl.py` and changed the behavior of the `exasol__get_columns_in_relation` to only return the datatype name in attribute `column_type` without additional information. So now it returns `VARCHAR` instead of `VARCHAR(200) UTF8`.