### PR TITLE
Feature/ts separator seed column quote

### DIFF
--- a/.stignore
+++ b/.stignore
@@ -1,5 +1,6 @@
+.git
 # Byte-compiled / optimized / DLL files
-__pycache__/
+__pycache__
 *.py[cod]
 *$py.class
 
@@ -8,21 +9,21 @@ __pycache__/
 
 # Distribution / packaging
 .Python
-build/
-develop-eggs/
-dist/
-downloads/
-eggs/
-.eggs/
-lib/
-lib64/
-parts/
-sdist/
-var/
-wheels/
-pip-wheel-metadata/
-share/python-wheels/
-*.egg-info/
+build
+develop-eggs
+dist
+downloads
+eggs
+.eggs
+lib
+lib64
+parts
+sdist
+var
+wheels
+pip-wheel-metadata
+share/python-wheels
+*.egg-info
 .installed.cfg
 *.egg
 MANIFEST
@@ -37,19 +38,6 @@ MANIFEST
 pip-log.txt
 pip-delete-this-directory.txt
 
-# Unit test / coverage reports
-htmlcov/
-.tox/
-.nox/
-.coverage
-.coverage.*
-.cache
-nosetests.xml
-coverage.xml
-*.cover
-.hypothesis/
-.pytest_cache/
-
 # Translations
 *.mo
 *.pot
@@ -58,37 +46,29 @@ coverage.xml
 *.log
 local_settings.py
 db.sqlite3
-db.sqlite3-journal
 
 # Flask stuff:
-instance/
+instance
 .webassets-cache
 
 # Scrapy stuff:
 .scrapy
 
 # Sphinx documentation
-docs/_build/
+docs/_build
 
 # PyBuilder
-target/
+target
 
 # Jupyter Notebook
 .ipynb_checkpoints
 
 # IPython
-profile_default/
+profile_default
 ipython_config.py
 
 # pyenv
 .python-version
-
-# pipenv
-#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
-#   However, in case of collaboration, if having platform-specific dependencies or dependencies
-#   having no cross-platform support, pipenv may install dependencies that don't work, or not
-#   install all needed dependencies.
-#Pipfile.lock
 
 # celery beat schedule file
 celerybeat-schedule
@@ -99,11 +79,11 @@ celerybeat-schedule
 # Environments
 .env
 .venv
-env/
-venv/
-ENV/
-env.bak/
-venv.bak/
+env
+venv
+ENV
+env.bak
+venv.bak
 
 # Spyder project settings
 .spyderproject
@@ -112,18 +92,10 @@ venv.bak/
 # Rope project settings
 .ropeproject
 
-# mkdocs documentation
-/site
-
 # mypy
-.mypy_cache/
+.mypy_cache
 .dmypy.json
 dmypy.json
 
 # Pyre type checker
-.pyre/
-
-.history/
-
-**/logs
-report.xml
+.pyre

--- a/dbt/adapters/exasol/impl.py
+++ b/dbt/adapters/exasol/impl.py
@@ -1,12 +1,14 @@
 """dbt-exasol Adapter implementation extending SQLAdapter"""
 from __future__ import absolute_import
 
-from typing import Dict
+from typing import Dict, Optional
 
 import agate
-from dbt.adapters.exasol import ExasolColumn, ExasolConnectionManager, ExasolRelation
 from dbt.adapters.sql import SQLAdapter
+from dbt.exceptions import raise_compiler_error
 from dbt.utils import filter_null_values
+
+from dbt.adapters.exasol import ExasolColumn, ExasolConnectionManager, ExasolRelation
 
 
 class ExasolAdapter(SQLAdapter):
@@ -61,3 +63,19 @@ class ExasolAdapter(SQLAdapter):
         the number in quotes without the interval
         """
         return f"{add_to} + interval '{number}' {interval}"
+
+    def quote_seed_column(self, column: str, quote_config: Optional[bool]) -> str:  # type: ignore
+        quote_columns: bool = False
+        if isinstance(quote_config, bool):
+            quote_columns = quote_config
+        elif quote_config is None:
+            pass
+        else:
+            raise_compiler_error(
+                f'The seed configuration value of "quote_columns" has an '
+                f"invalid type {type(quote_config)}"
+            )
+
+        if quote_columns:
+            return self.quote(column)
+        return column

--- a/okteto.yml
+++ b/okteto.yml
@@ -1,0 +1,21 @@
+name: auxmoney
+autocreate: true
+image: alligatorcompany/acs-workbench:latest
+command: zsh
+namespace: dev-torsten
+
+sync:
+  - .:/wks
+workdir: /wks
+
+environment:
+  - DBT_USER=sys
+  - DBT_PASS=start123
+  - DBT_PROFILES_DIR=.
+  - EXASOL_SERVICE_HOST=exasol
+  - EXASOL_SERVICE_PORT=8563
+
+forward:
+  - 8563:exasol:8563
+  - 8000:dvb:8000
+  - 8001:dvb:3000

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,9 +15,9 @@ readme = "README.md"
 
 [tool.poetry.dependencies]
 python = "^3.7.2, <4"
-dbt-core = "1.2.1"
+dbt-core = "^1.2.1, <1.3"
 pyexasol = "^0.25.0"
-dbt-tests-adapter = "^1.2.1"
+dbt-tests-adapter = "^1.2.1, <1.3"
 
 [tool.poetry.dev-dependencies]
 black = "^22.8.0"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,13 +1,22 @@
+"""pytest conftest to load base dbt project fixtures
+"""
 import os
-from dotenv import load_dotenv
-import pytest
 
-pytest_plugins = ["dbt.tests.fixtures.project"]
+import pytest
+from dotenv import load_dotenv
 
 load_dotenv()
 
+pytest_plugins = ["dbt.tests.fixtures.project"]
+
+
 @pytest.fixture(scope="class")
 def dbt_profile_target():
+    """Fixture overwrite from dbt-core to configure profiles.yml
+
+    Returns:
+        dict: key values for profiles.yml
+    """
     return {
         "type": "exasol",
         "threads": 1,

--- a/tests/functional/fixtures.py
+++ b/tests/functional/fixtures.py
@@ -1,10 +1,10 @@
 # seeds/my_seed.csv
 my_seed_csv = """
 ID,NAME,SOME_DATE
-1,Easton,1981-05-20 06:46:51
-2,Lillian,1978-09-03 18:10:33
-3,Jeremiah,1982-03-11 03:59:51
-4,Nolan,1976-05-06 20:21:35
+1,Easton,1981-05-20T06:46:51
+2,Lillian,1978-09-03T18:10:33
+3,Jeremiah,1982-03-11T03:59:51
+4,Nolan,1976-05-06T20:21:35
 """.lstrip()
 
 # models/my_model.sql

--- a/tests/functional/test_basic.py
+++ b/tests/functional/test_basic.py
@@ -1,5 +1,3 @@
-import pytest
-from dbt.tests.adapter.basic.files import generic_test_seed_yml
 from dbt.tests.adapter.basic.test_adapter_methods import BaseAdapterMethod
 from dbt.tests.adapter.basic.test_base import BaseSimpleMaterializations
 from dbt.tests.adapter.basic.test_empty import BaseEmpty
@@ -13,20 +11,9 @@ from dbt.tests.adapter.basic.test_singular_tests_ephemeral import (
 from dbt.tests.adapter.basic.test_snapshot_check_cols import BaseSnapshotCheckCols
 from dbt.tests.adapter.basic.test_snapshot_timestamp import BaseSnapshotTimestamp
 
-from files import (
-    seeds_added_csv,
-    seeds_ansits_csv,
-    seeds_base_csv,
-    seeds_newcolumns_csv,
-)
-
 
 class TestSimpleMaterializationsMyAdapter(BaseSimpleMaterializations):
-    @pytest.fixture(scope="class")
-    def seeds(self):
-        return {
-            "base.csv": seeds_ansits_csv,
-        }
+    pass
 
 
 class TestSingularTestsMyAdapter(BaseSingularTests):
@@ -34,11 +21,7 @@ class TestSingularTestsMyAdapter(BaseSingularTests):
 
 
 class TestSingularTestsEphemeralMyAdapter(BaseSingularTestsEphemeral):
-    @pytest.fixture(scope="class")
-    def seeds(self):
-        return {
-            "base.csv": seeds_base_csv,
-        }
+    pass
 
 
 class TestEmptyMyAdapter(BaseEmpty):
@@ -46,45 +29,23 @@ class TestEmptyMyAdapter(BaseEmpty):
 
 
 class TestEphemeralMyAdapter(BaseEphemeral):
-    @pytest.fixture(scope="class")
-    def seeds(self):
-        return {
-            "base.csv": seeds_base_csv,
-        }
+    pass
 
 
 class TestIncrementalMyAdapter(BaseIncremental):
-    @pytest.fixture(scope="class")
-    def seeds(self):
-        return {"base.csv": seeds_base_csv, "added.csv": seeds_added_csv}
+    pass
 
 
 class TestGenericTestsMyAdapter(BaseGenericTests):
-    @pytest.fixture(scope="class")
-    def seeds(self):
-        return {
-            "base.csv": seeds_base_csv,
-            "schema.yml": generic_test_seed_yml,
-        }
+    pass
 
 
 class TestSnapshotCheckColsMyAdapter(BaseSnapshotCheckCols):
-    @pytest.fixture(scope="class")
-    def seeds(self):
-        return {
-            "base.csv": seeds_base_csv,
-            "added.csv": seeds_added_csv,
-        }
+    pass
 
 
 class TestSnapshotTimestampMyAdapter(BaseSnapshotTimestamp):
-    @pytest.fixture(scope="class")
-    def seeds(self):
-        return {
-            "base.csv": seeds_base_csv,
-            "newcolumns.csv": seeds_newcolumns_csv,
-            "added.csv": seeds_added_csv,
-        }
+    pass
 
 
 class TestBaseAdapterMethod(BaseAdapterMethod):

--- a/tests/functional/test_failing_test.py
+++ b/tests/functional/test_failing_test.py
@@ -1,9 +1,10 @@
 """
 testing sample
 """
+import os
+
 import pytest
 from dbt.tests.util import run_dbt
-
 from fixtures import my_model_sql, my_model_yml, my_seed_csv
 
 

--- a/tests/functional/test_issues.py
+++ b/tests/functional/test_issues.py
@@ -1,0 +1,58 @@
+import os
+
+import pytest
+from dbt.tests.adapter.basic.files import config_materialized_view
+from dbt.tests.util import run_dbt
+
+
+@pytest.fixture(scope="class")
+def dbt_profile_target():
+    return {
+        "type": "exasol",
+        "threads": 1,
+        "dsn": os.getenv("DBT_DSN"),
+        "user": os.getenv("DBT_USER"),
+        "pass": os.getenv("DBT_PASS"),
+        "dbname": "DB",
+        "timestamp_format": "YYYY-MM-DD HH:MI:SS",
+    }
+
+
+base_view_sql = config_materialized_view + "select 1 as id;"
+
+seeds_tsspace_csv = """
+id,name,some_date
+1,Easton,1981-05-20 06:46:51
+2,Lillian,1978-09-03 18:10:33
+3,Jeremiah,1982-03-11 03:59:51
+4,Nolan,1976-05-06 20:21:35
+5,Hannah,1982-06-23 05:41:26
+6,Eleanor,1991-08-10 23:12:21
+7,Lily,1971-03-29 14:58:02
+8,Jonathan,1988-02-26 02:55:24
+9,Adrian,1994-02-09 13:14:23
+10,Nora,1976-03-01 16:51:39
+""".lstrip()
+
+
+class TestViewModelSemicolon:
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {"view_model.sql": base_view_sql}
+
+    def test_view(self, project):
+        results = run_dbt(["build"], expect_pass=False)
+        assert len(results) == 1
+        assert results[0].status == "error"
+
+
+class TestCustomTimestampFormat:
+    @pytest.fixture(scope="class")
+    def seeds(self):
+        return {"ts_space.csv": seeds_tsspace_csv}
+
+    def test_custom_ts_format(self, project):
+
+        results = run_dbt(["seed"])
+        assert len(results) == 1
+        assert results[0].status == "success"

--- a/tox.ini
+++ b/tox.ini
@@ -3,11 +3,9 @@ isolated_build = True
 envlist = python3.7,py38,py39,py310
 
 [testenv]
+passenv = *
 allowlist_externals = poetry
                       pytest
-#skip_install = False
-#passenv = DBT_* PYTEST_ADDOPTS
 commands =
     poetry install -v
-    pytest {posargs} tests
-
+    pytest --junitxml=report.xml tests


### PR DESCRIPTION
- timestamp format via alter session NLS_TIMESTAMP_FORMAT parameter in exasol
- default format is set to have T as separator between date and time - bc thats the default of dbt-labs pytest suite
- on the way realized seed_column_quote was True by default - see https://github.com/dbt-labs/dbt-core/issues/3898