### PR TITLE
Fix innoverio.vscode-dbt-power-user Exasol errors

### DIFF
--- a/dbt/adapters/exasol/connections.py
+++ b/dbt/adapters/exasol/connections.py
@@ -263,7 +263,10 @@ class ExasolCursor:
             for sql in sqls:
                 self.stmt = self.connection.execute(sql)
         else:
-            self.stmt = self.connection.execute(query)
+            try:
+                self.stmt = self.connection.execute(query)
+            except pyexasol.ExaQueryError as e:
+                raise dbt.exceptions.DbtDatabaseError("Exasol Query Error: " + e.message)
         return self
 
     def fetchone(self):


### PR DESCRIPTION
The innoverio.vscode-dbt-power-user VScode extension expects all errors coming from DBT adapters to be raised as DBT errors. The dbt-exasol adapter was raising Exasol DB errors as pyexasol's QueryError error type and so this caused problems in the vscode extension.

This commit changes the error to the standard DBT DB error type.