### PR TITLE
Fix cache inconsistency errors with parallel model builds

### DIFF
--- a/dbt/include/exasol/macros/materializations/table.sql
+++ b/dbt/include/exasol/macros/materializations/table.sql
@@ -1,0 +1,44 @@
+{% materialization table, adapter='exasol' %}
+  {#
+    Exasol table materialization using CREATE OR REPLACE TABLE directly.
+
+    Exasol supports atomic CREATE OR REPLACE TABLE, so we skip the
+    intermediate/backup/rename pattern used by dbt-core default.
+    This avoids cache inconsistency errors with parallel model builds.
+  #}
+
+  {%- set identifier = model['alias'] -%}
+  {%- set old_relation = adapter.get_relation(database=database, schema=schema, identifier=identifier) -%}
+  {%- set exists_as_target_type = (old_relation is not none and old_relation.is_table) -%}
+  {%- set target_relation = api.Relation.create(
+      identifier=identifier,
+      schema=schema,
+      database=database,
+      type='table'
+  ) -%}
+  {% set grant_config = config.get('grants') %}
+
+  {{ run_hooks(pre_hooks) }}
+
+  {#
+      We only need to drop this thing if it is not a table.
+      If it _is_ already a table, then we can overwrite it without downtime.
+  #}
+  {%- if old_relation is not none and not old_relation.is_table -%}
+    {{ adapter.drop_relation(old_relation) }}
+  {%- endif -%}
+
+  {% call statement('main') -%}
+    {{ create_table_as(False, target_relation, sql) }}
+  {%- endcall %}
+
+  {% set should_revoke = should_revoke(exists_as_target_type, full_refresh_mode=True) %}
+  {% do apply_grants(target_relation, grant_config, should_revoke=should_revoke) %}
+
+  {% do persist_docs(target_relation, model) %}
+
+  {{ run_hooks(post_hooks) }}
+
+  {{ return({'relations': [target_relation]}) }}
+
+{% endmaterialization %}

--- a/dbt/include/exasol/macros/materializations/view.sql
+++ b/dbt/include/exasol/macros/materializations/view.sql
@@ -1,0 +1,44 @@
+{% materialization view, adapter='exasol' %}
+  {#
+    Exasol view materialization using CREATE OR REPLACE VIEW directly.
+
+    Exasol supports atomic CREATE OR REPLACE VIEW, so we skip the
+    intermediate/backup/rename pattern used by dbt-core default.
+    This avoids cache inconsistency errors with parallel model builds.
+  #}
+
+  {%- set identifier = model['alias'] -%}
+  {%- set old_relation = adapter.get_relation(database=database, schema=schema, identifier=identifier) -%}
+  {%- set exists_as_target_type = (old_relation is not none and old_relation.is_view) -%}
+  {%- set target_relation = api.Relation.create(
+      identifier=identifier,
+      schema=schema,
+      database=database,
+      type='view'
+  ) -%}
+  {% set grant_config = config.get('grants') %}
+
+  {{ run_hooks(pre_hooks) }}
+
+  {#
+      We only need to drop this thing if it is not a view.
+      If it _is_ already a view, then we can overwrite it without downtime.
+  #}
+  {%- if old_relation is not none and not old_relation.is_view -%}
+    {{ adapter.drop_relation(old_relation) }}
+  {%- endif -%}
+
+  {% call statement('main') -%}
+    {{ get_create_view_as_sql(target_relation, sql) }}
+  {%- endcall %}
+
+  {% set should_revoke = should_revoke(exists_as_target_type, full_refresh_mode=True) %}
+  {% do apply_grants(target_relation, grant_config, should_revoke=should_revoke) %}
+
+  {% do persist_docs(target_relation, model) %}
+
+  {{ run_hooks(post_hooks) }}
+
+  {{ return({'relations': [target_relation]}) }}
+
+{% endmaterialization %}


### PR DESCRIPTION
## Summary

Override table and view materializations to use Exasol's native `CREATE OR REPLACE` directly, avoiding the intermediate/backup/rename pattern that causes cache inconsistency errors during parallel builds.

## Problems Fixed

### 1. Cache inconsistency errors during parallel builds

When running dbt with multiple threads, the default dbt-core table/view materializations can fail with:

```
Cache inconsistency detected: in rename, new key
_ReferenceKey(database=None, schema='...', identifier='...')
already in cache
```

This occurs because dbt-core's cache rename logic has a race condition where `_setdefault` is called instead of `_rename_relation`, causing both old and new keys to exist simultaneously.

### 2. Leftover temporary tables after failed runs

The default materialization creates intermediate tables (`*__dbt_tmp`) and backup tables (`*__dbt_backup`) during execution. If a dbt run fails mid-execution, these temporary tables are left behind in the database and must be cleaned up manually.

## Solution

Exasol supports atomic `CREATE OR REPLACE TABLE/VIEW`, making the intermediate/backup/rename dance unnecessary. The new materializations:

1. Check if existing relation is a different type (table↔view)
2. Drop only if type mismatch
3. Execute `CREATE OR REPLACE` directly
4. Skip all rename operations — no intermediate or backup tables created

## Changes

- `dbt/include/exasol/macros/materializations/table.sql` - New table materialization
- `dbt/include/exasol/macros/materializations/view.sql` - New view materialization

## Testing

- All 307 functional tests pass
- Specifically verified:
  - `test_changing_materialization_changes_relation_type` - table↔view conversion
  - `test_simple_copy` - basic table/view builds
  - `test_concurrency` - parallel builds