### PR TITLE
Update comment for field name alias in connections.py

### DIFF
--- a/dbt/adapters/exasol/connections.py
+++ b/dbt/adapters/exasol/connections.py
@@ -127,7 +127,7 @@ class ExasolCredentials(Credentials):
     row_separator: str = ROW_SEPARATOR_DEFAULT
     timestamp_format: str = TIMESTAMP_FORMAT_DEFAULT
 
-    _ALIASES = {"dbname": "database", "pass": "password"}  # NOSONAR(B105) field name alias, not actual password
+    _ALIASES = {"dbname": "database", "pass": "password"}  # nosec: B105 - field name alias, not actual password
 
     @property
     def type(self):


### PR DESCRIPTION
Switched from `NOSONAR` to `nosec` syntax.