### PR TITLE
Prepare v1.12.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,37 @@
 # Changelog
 
+## 1.12.0 — dbt-core 1.12 support
+
+Supports **dbt-core 1.12** and adopts its new adapter-facing features. See the
+[dbt-core version parity matrix](README.md#dbt-core-version-parity) for the full
+feature list.
+
+### Added
+- Support for **dbt-core 1.12** (`dbt-core>=1.12.0,<1.13`, `dbt-adapters>=1.24.5`).
+- Empty-seed support: `dbt seed --empty` and `dbt build --empty` create correctly
+  typed empty tables; covered by the upstream `BaseTestEmptySeedFlag` suite.
+  Known limitation: an `--empty` seed followed immediately by a plain
+  (non-`--full-refresh`) `seed` on a CSV with decimal columns is not fully
+  validated — use `dbt seed --full-refresh` to reload (see README).
+- Functional coverage for `latest_version_pointer`: versioned models
+  automatically get a pointer view named after the base model (dbt-core 1.12).
+- `Capability.CatalogsV2` declared as `Unsupported`.
+- Python 3.14 support; Python support window is now **3.11–3.14**
+  (3.10 dropped).
+
+### Changed
+- `ExasolCursor.fetchone`/`fetchmany`/`fetchall` now raise
+  `dbt_common.exceptions.DbtRuntimeError` instead of a raw `RuntimeError` when
+  called on an unset statement, aligning with dbt-core 1.12 exception handling.
+- `convert_number_type` returns `float` for zero-row agate tables (e.g. empty
+  seeds) instead of letting `agate.MaxPrecision` degrade decimal columns to
+  `integer`.
+
+### Fixed
+- Column comments (`persist_docs`) are now applied only to columns that
+  actually exist in the relation, using `validate_doc_columns`; stale model
+  column definitions no longer break comment propagation.
+
 ## 1.11.0 — dbt-core 1.11 parity
 
 Establishes an explicit, testable parity claim against **dbt-core 1.11** (reference

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,9 @@ dev = [
   "black>=22.8,<27.0",
   "dbt-tests-adapter>=1.20.0",
   "exasol-integration-test-docker-environment>=4.3.0",
-  "exasol-toolbox>=5.1.0",
+  # Pinned <7: toolbox 10.x removed `_version` from exasol.toolbox.nox._shared
+  # which noxfile.py imports; migration to the new API is a follow-up task.
+  "exasol-toolbox>=5.1.0,<7",
   "exceptiongroup>=1.1.1",
   "freezegun>=1.2.2",
   "ipykernel>=6.25.0",

--- a/tests/functional/adapter/files.py
+++ b/tests/functional/adapter/files.py
@@ -26,9 +26,7 @@ ID,NAME,SOME_DATE
 10,Nora,1976-03-01 16:51:39
 """.lstrip()
 
-seeds_added_csv = (
-    seeds_base_csv
-    + """
+seeds_added_csv = seeds_base_csv + """
 11,Mateo,2014-09-07 17:04:27
 12,Julian,2000-02-04 11:48:30
 13,Gabriel,2001-07-10 07:32:52
@@ -40,7 +38,6 @@ seeds_added_csv = (
 19,Jayden,2009-06-06 07:12:49
 20,Luke,2003-12-05 21:42:18
 """.lstrip()
-)
 
 seeds_newcolumns_csv = """
 id,name,some_date,last_initial

--- a/tests/functional/adapter/incremental/test_incremental_microbatch.py
+++ b/tests/functional/adapter/incremental/test_incremental_microbatch.py
@@ -104,12 +104,10 @@ class TestMicrobatchLookback:
         )
 
         # Insert new data for day 3
-        project.run_sql(
-            """
+        project.run_sql("""
             insert into {schema}.input_model (id, event_time)
             values (99, TIMESTAMP '2020-01-03 12:00:00')
-        """
-        )
+        """)
 
         # Second run - only select microbatch model to avoid rebuilding input
         run_dbt(

--- a/tests/functional/adapter/limit/test_limit.py
+++ b/tests/functional/adapter/limit/test_limit.py
@@ -17,7 +17,7 @@ class TestLimitExasol(BaseSimpleMaterializations):
         run_dbt(["seed"])
         run_dbt(["build"])
 
-        (results, log_output) = run_dbt_and_capture(["show", "--select", "view_model", "--limit", "5"])
+        results, log_output = run_dbt_and_capture(["show", "--select", "view_model", "--limit", "5"])
         assert len(results) == 1
         assert "Previewing node 'sample_model'" not in log_output
         assert "Previewing node 'view_model'" in log_output

--- a/tests/functional/adapter/simple_seed/test_seed_keywords.py
+++ b/tests/functional/adapter/simple_seed/test_seed_keywords.py
@@ -148,12 +148,10 @@ class TestSeedMixedQuoting:
 
     @pytest.fixture(scope="class")
     def seeds(self):
-        return {
-            "mixed_cols.csv": """id,name,value,description,order
+        return {"mixed_cols.csv": """id,name,value,description,order
 1,Product A,active,desc1,100
 2,Product B,pending,desc2,200
-"""
-        }
+"""}
 
     def test_seed_mixed_columns(self, project):
         """Test that only keyword columns are quoted."""
@@ -192,12 +190,10 @@ class TestSeedKeywordsUppercase:
 
     @pytest.fixture(scope="class")
     def seeds(self):
-        return {
-            "uppercase_keywords.csv": """ID,VALUE,ORDER,FROM
+        return {"uppercase_keywords.csv": """ID,VALUE,ORDER,FROM
 1,active,100,source1
 2,pending,101,source2
-"""
-        }
+"""}
 
     def test_seed_uppercase_keywords(self, project):
         """Test that uppercase keyword columns are properly quoted."""

--- a/tests/functional/adapter/simple_snapshot/test_snapshot_composite_key.py
+++ b/tests/functional/adapter/simple_snapshot/test_snapshot_composite_key.py
@@ -117,11 +117,9 @@ class TestSnapshotCompositeKey:
         run_dbt(["snapshot"])
 
         # Update record (NA, PROD001)
-        project.run_sql(
-            """UPDATE {schema}.seed_composite
+        project.run_sql("""UPDATE {schema}.seed_composite
                SET sales = 110, some_date = '2020-01-15T00:00:00.000000'
-               WHERE region = 'NA' AND product_id = 'PROD001'"""
-        )
+               WHERE region = 'NA' AND product_id = 'PROD001'""")
 
         # Run snapshot again
         run_dbt(["snapshot"])
@@ -169,16 +167,12 @@ class TestSnapshotCompositeKey:
         run_dbt(["snapshot"])
 
         # Update two records
-        project.run_sql(
-            """UPDATE {schema}.seed_composite
+        project.run_sql("""UPDATE {schema}.seed_composite
                SET sales = 110, some_date = '2020-01-15T00:00:00.000000'
-               WHERE region = 'NA' AND product_id = 'PROD001'"""
-        )
-        project.run_sql(
-            """UPDATE {schema}.seed_composite
+               WHERE region = 'NA' AND product_id = 'PROD001'""")
+        project.run_sql("""UPDATE {schema}.seed_composite
                SET sales = 160, some_date = '2020-01-15T00:00:00.000000'
-               WHERE region = 'EU' AND product_id = 'PROD001'"""
-        )
+               WHERE region = 'EU' AND product_id = 'PROD001'""")
 
         # Run snapshot again
         run_dbt(["snapshot"])
@@ -214,10 +208,8 @@ class TestSnapshotCompositeKeyWithInvalidate:
         run_dbt(["snapshot"])
 
         # Delete record (NA, PROD001)
-        project.run_sql(
-            """DELETE FROM {schema}.seed_composite
-               WHERE region = 'NA' AND product_id = 'PROD001'"""
-        )
+        project.run_sql("""DELETE FROM {schema}.seed_composite
+               WHERE region = 'NA' AND product_id = 'PROD001'""")
 
         # Run snapshot again
         run_dbt(["snapshot"])
@@ -267,10 +259,8 @@ class TestSnapshotCompositeKeyWithNewRecord:
         assert results[0] == 5, f"Expected 5 records with dbt_is_deleted='False', got {results[0]}"
 
         # Delete record (NA, PROD001)
-        project.run_sql(
-            """DELETE FROM {schema}.seed_composite
-               WHERE region = 'NA' AND product_id = 'PROD001'"""
-        )
+        project.run_sql("""DELETE FROM {schema}.seed_composite
+               WHERE region = 'NA' AND product_id = 'PROD001'""")
 
         # Run snapshot again
         run_dbt(["snapshot"])
@@ -322,11 +312,9 @@ class TestSnapshotTripleKey:
         assert results[0] == 5, f"Expected 5 current records, got {results[0]}"
 
         # Update a record - since sales is part of the key, this creates a new key
-        project.run_sql(
-            """UPDATE {schema}.seed_composite
+        project.run_sql("""UPDATE {schema}.seed_composite
                SET some_date = '2020-01-15T00:00:00.000000'
-               WHERE region = 'NA' AND product_id = 'PROD001'"""
-        )
+               WHERE region = 'NA' AND product_id = 'PROD001'""")
 
         run_dbt(["snapshot"])
 

--- a/tests/functional/adapter/simple_snapshot/test_snapshot_reserved_keywords.py
+++ b/tests/functional/adapter/simple_snapshot/test_snapshot_reserved_keywords.py
@@ -183,11 +183,9 @@ class TestSnapshotReservedKeywords:
         run_dbt(["snapshot"])
 
         # Update record with field_id=1
-        project.run_sql(
-            """UPDATE {schema}.source_reserved_keywords
+        project.run_sql("""UPDATE {schema}.source_reserved_keywords
                SET "user" = 'alice_updated', "date" = '2020-01-15'
-               WHERE field_id = 1"""
-        )
+               WHERE field_id = 1""")
 
         # Run snapshot again
         run_dbt(["snapshot"])
@@ -249,11 +247,9 @@ class TestSnapshotReservedKeywordsCheck:
         run_dbt(["snapshot"])
 
         # Update the 'time' column (a reserved keyword)
-        project.run_sql(
-            """UPDATE {schema}.source_reserved_keywords
+        project.run_sql("""UPDATE {schema}.source_reserved_keywords
                SET "time" = TO_TIMESTAMP('2020-01-15T10:00:00.000000', 'YYYY-MM-DDTHH:MI:SS.FF6')
-               WHERE field_id = 1"""
-        )
+               WHERE field_id = 1""")
 
         # Run snapshot again
         run_dbt(["snapshot"])
@@ -295,10 +291,8 @@ class TestSnapshotReservedKeywordsWithNewRecord:
         assert results[0] == 5, f"Expected 5 records with dbt_is_deleted='False', got {results[0]}"
 
         # Delete record with field_id=1
-        project.run_sql(
-            """DELETE FROM {schema}.source_reserved_keywords
-               WHERE field_id = 1"""
-        )
+        project.run_sql("""DELETE FROM {schema}.source_reserved_keywords
+               WHERE field_id = 1""")
 
         # Run snapshot again
         run_dbt(["snapshot"])
@@ -355,11 +349,9 @@ class TestSnapshotMixedColumnTypes:
         run_dbt(["snapshot"])
 
         # Update the reserved keyword column
-        project.run_sql(
-            """UPDATE {schema}.source_mixed_columns
+        project.run_sql("""UPDATE {schema}.source_mixed_columns
                SET "time" = TO_TIMESTAMP('2020-01-15T10:00:00.000000', 'YYYY-MM-DDTHH:MI:SS.FF6')
-               WHERE ID = 1"""
-        )
+               WHERE ID = 1""")
 
         # Run snapshot again
         run_dbt(["snapshot"])
@@ -435,11 +427,9 @@ class TestSnapshotQuotedUppercaseIdentifier:
         run_dbt(["snapshot"])
 
         # Update the source column that feeds EXPLICIT_TIME
-        project.run_sql(
-            """UPDATE {schema}.source_mixed_columns
+        project.run_sql("""UPDATE {schema}.source_mixed_columns
                SET "time" = TO_TIMESTAMP('2020-01-15T10:00:00.000000', 'YYYY-MM-DDTHH:MI:SS.FF6')
-               WHERE ID = 1"""
-        )
+               WHERE ID = 1""")
 
         # Run snapshot again
         run_dbt(["snapshot"])

--- a/uv.lock
+++ b/uv.lock
@@ -1052,7 +1052,7 @@ dev = [
     { name = "black", specifier = ">=22.8,<27.0" },
     { name = "dbt-tests-adapter", specifier = ">=1.20.0" },
     { name = "exasol-integration-test-docker-environment", specifier = ">=4.3.0" },
-    { name = "exasol-toolbox", specifier = ">=5.1.0" },
+    { name = "exasol-toolbox", specifier = ">=5.1.0,<7" },
     { name = "exceptiongroup", specifier = ">=1.1.1" },
     { name = "freezegun", specifier = ">=1.2.2" },
     { name = "ipykernel", specifier = ">=6.25.0" },
@@ -1251,7 +1251,7 @@ name = "docker"
 version = "7.2.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pywin32", marker = "sys_platform == 'win32'" },
+    { name = "pywin32", marker = "python_version < '0'" },
     { name = "requests" },
     { name = "urllib3" },
 ]
@@ -1368,7 +1368,7 @@ wheels = [
 
 [[package]]
 name = "exasol-toolbox"
-version = "10.3.0"
+version = "6.4.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "bandit" },
@@ -1403,11 +1403,10 @@ dependencies = [
     { name = "structlog" },
     { name = "twine" },
     { name = "typer" },
-    { name = "zizmor" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/86/ef/af2be048161a313ef5e9c6c1146544252df6994396036d96edfe4b3dc3ea/exasol_toolbox-10.3.0.tar.gz", hash = "sha256:b9514dfb3a6e34f6b7d79bcd54aff4febb3f78ac9255b345a16ecdb92c8ed1d0", size = 65805, upload-time = "2026-07-15T08:33:04.108Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/bd/d4/c43116cf5fe739e89418fb3da27fd30105c5ee9fa214444a0a2fd47e01da/exasol_toolbox-6.4.0.tar.gz", hash = "sha256:a9bc800adfdd1e32252f8f345aa9c308ec43edc04b1ea87bd547164c9301ce71", size = 58521, upload-time = "2026-04-22T08:46:10.053Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/12/d9/e033e86efba5f38adbd7e3c65373857b8c3efb19f0d45bfcfe6c28ae18af/exasol_toolbox-10.3.0-py3-none-any.whl", hash = "sha256:79e9b2abe81617feed57ac390439902733611e2b67964a65d911ec16590d4e51", size = 99600, upload-time = "2026-07-15T08:33:05.154Z" },
+    { url = "https://files.pythonhosted.org/packages/94/f0/8b7619f30b8f5deb0a6115f7d693f999fa68086d94aa1e252b0af24fc3fc/exasol_toolbox-6.4.0-py3-none-any.whl", hash = "sha256:8f23140155b1e2f3f42ce40951d1e9388b4c01ac7a28e789d964679315a162cb", size = 88595, upload-time = "2026-04-22T08:46:11.376Z" },
 ]
 
 [[package]]
@@ -4937,22 +4936,4 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/b9/d8/eab98a517c14134c0b2eb4e2387bc5f457334293ec5d2dd3857ec2966802/zipp-4.1.0.tar.gz", hash = "sha256:4cb57381f544315db7688e976e922a2b18cdb513d21cc194eb42232ba2a3e602", size = 26214, upload-time = "2026-05-18T20:08:57.967Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/3a/13/547360d81e6d88d58492968ffda9f9542854f11310ee556fef14260cc886/zipp-4.1.0-py3-none-any.whl", hash = "sha256:25ad4e16390cd314347dd8f1de67a2ac538ae658ed4ab9db16029c07c188e97f", size = 10238, upload-time = "2026-05-18T20:08:57.045Z" },
-]
-
-[[package]]
-name = "zizmor"
-version = "1.28.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/64/92/6b58872ac1184a441037bdc05c658a3900f49401b25f6e834a268ef6ff52/zizmor-1.28.0.tar.gz", hash = "sha256:6d5a300b80bf4c12e9cbe78ffd3874ec3f94b65bea78c994ec18157e2846ece0", size = 550169, upload-time = "2026-07-21T22:16:27.361Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/e8/48/a725a1c34e5565eeeb4e4a93c59662f206e5156f2029627c66b2373edf55/zizmor-1.28.0-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:149dba59a8bd2897960ee54c40ae8b5801a71293bad71c8d2913c74ab66a294c", size = 8909502, upload-time = "2026-07-21T22:16:07.47Z" },
-    { url = "https://files.pythonhosted.org/packages/20/92/ba6d0eb2b336b4c4826bb0c9ed23c3239d46d71d8c1ddd2d395efeff7f52/zizmor-1.28.0-py3-none-macosx_11_0_arm64.whl", hash = "sha256:0949f57a6d20deeb9c509705afce8de233c166475e25be305985a1fe553c6e0d", size = 8520554, upload-time = "2026-07-21T22:16:09.587Z" },
-    { url = "https://files.pythonhosted.org/packages/4f/07/69aba8157056fc0949cbdc787d8437813961e204a117c629d34afc827d6d/zizmor-1.28.0-py3-none-manylinux_2_24_aarch64.whl", hash = "sha256:9819f91f0ef486e4af98a6aacfed23c6b4067fabcecb88d49231228a3d43f821", size = 8759226, upload-time = "2026-07-21T22:16:11.627Z" },
-    { url = "https://files.pythonhosted.org/packages/69/33/b65717a3ca4573611f47612e67be5458ff700e857f49f759741fa67b0519/zizmor-1.28.0-py3-none-manylinux_2_28_armv7l.whl", hash = "sha256:354e6cb98a15a88593a6f7ac6236b092b83a2aad5c4768ee750f9b3262f668d9", size = 8382005, upload-time = "2026-07-21T22:16:13.896Z" },
-    { url = "https://files.pythonhosted.org/packages/5b/b4/f823bd2a1ba6dc432fdcbd249d4c442ce79bd137d34d986fce5c181f2800/zizmor-1.28.0-py3-none-manylinux_2_28_x86_64.whl", hash = "sha256:ae2cab67ce713e760e0d1b61ad749d374693ea2b310337aab11cd446748267f3", size = 9175601, upload-time = "2026-07-21T22:16:16.177Z" },
-    { url = "https://files.pythonhosted.org/packages/f3/75/adad17b0320eb3bc9ed797019fccf69a809affdf5ba9402bdc8b910957e1/zizmor-1.28.0-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:7b00018cf2cc948c3b3e010c1a1f30fdc001f0d062640469f17e0ef006e74eb7", size = 8792861, upload-time = "2026-07-21T22:16:18.035Z" },
-    { url = "https://files.pythonhosted.org/packages/1a/3d/4d5583f24730f404c104eacf8aca4ca5a3d4c480e9d3cfe3eadd93351fd6/zizmor-1.28.0-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:6897f02b0d02fd709f5ebc13cd37d97ad464219e0ba86a03f6d86f7777b7b102", size = 8343070, upload-time = "2026-07-21T22:16:20.092Z" },
-    { url = "https://files.pythonhosted.org/packages/97/e2/4521e6dd56bc0d44eefb177794e261925c5cd00ab647b17e5513bddcb985/zizmor-1.28.0-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:ef69d198dcf6835c9b6eea8673cbc5c36f10b3f1b98b51d28266b7e01c3704d4", size = 9262222, upload-time = "2026-07-21T22:16:21.89Z" },
-    { url = "https://files.pythonhosted.org/packages/a2/96/5d841d197c821921cb8243352c610ca2505a86871c10f81efe4da190d24c/zizmor-1.28.0-py3-none-win32.whl", hash = "sha256:833c360ba5a9c74ca45007b8c79939826fca0c5ed65144fa08f63a7009cef096", size = 7541161, upload-time = "2026-07-21T22:16:23.965Z" },
-    { url = "https://files.pythonhosted.org/packages/b1/f5/3f4591746e5a9c7e8efc2e9e02aa43e1aa0957fe33cae64ce386c74b882e/zizmor-1.28.0-py3-none-win_amd64.whl", hash = "sha256:c93b30d211b0b0c38905a8803cc2653fff37de03eb77105302a02f709773bd4a", size = 8619340, upload-time = "2026-07-21T22:16:25.6Z" },
 ]


### PR DESCRIPTION
## Summary

Release preparation for **v1.12.0**:

- **Fix broken master CI (blocker):** dependabot's black 24→26 bump (`6e1fe86`) re-locked `uv.lock` and silently pulled `exasol-toolbox` 6.1.0 → 10.3.0, which removed `_version` from `exasol.toolbox.nox._shared` (imported by `noxfile.py`). Every nox session broke, master CI went red in the Setup job, and the release workflow's "Verify CI Passed" gate would abort a tag at HEAD. This PR pins `exasol-toolbox>=5.1.0,<7` (resolves to 6.4.0) until nox tooling is migrated to the toolbox 10 API (follow-up issue).
- **CHANGELOG.md:** adds the `1.12.0 — dbt-core 1.12 support` entry (dbt-core 1.12 + dependency floors, empty-seed support, `latest_version_pointer` coverage, `CatalogsV2` capability declaration, Python 3.11–3.14 window, `DbtRuntimeError` cursor hardening, `convert_number_type` empty-seed fix, `persist_docs` column fix).
- **black 26.3.1 formatting:** 6 test files mechanically reformatted so `format:check` passes with the bumped black.

## Verification (local, worktree)

- `nox -s matrix:python` ✅ (ImportError gone)
- `nox -s format:check` ✅ (ruff, isort, black 26.3.1)
- `nox -s test:unit` ✅ 238 passed

## Release steps after merge

1. Wait for green push-CI on the master merge commit (checks + integration)
2. `git tag v1.12.0 <merge-sha> && git push origin v1.12.0` → release.yml publishes to PyPI and creates the GitHub release